### PR TITLE
Update JWT token cookie to include max_age

### DIFF
--- a/src/airflow_ldap_auth_manager/ldap_auth_manager.py
+++ b/src/airflow_ldap_auth_manager/ldap_auth_manager.py
@@ -717,7 +717,9 @@ class LdapAuthManager(BaseAuthManager[LdapUser]):
             target = _sanitize_next(next_param, request) # type: ignore[arg-type]
             resp = RedirectResponse(url=target or "/", status_code=303)
             secure = (request.base_url.scheme == "https") or bool(conf.get("api", "ssl_cert", fallback=""))
-            resp.set_cookie(COOKIE_NAME_JWT_TOKEN, token, secure=secure, httponly=False, samesite="lax", path="/")
+            resp.set_cookie(
+                COOKIE_NAME_JWT_TOKEN, token, secure=secure, httponly=False, samesite='lax', path='/', max_age=exp_secs
+            )
             return resp
 
         @router.get("/logout")


### PR DESCRIPTION
**Problem:**
After some time (looks like 1 day), I'm starting to see 500 errors in the UI.

**Proposed solution:**
Add the max_age parameter to the JWT token cookie.

It seems that the refresh token approach is also possible, but it's more complex, which is why I added a simple cookie expiration.