### PR TITLE
Fix for logout not working

### DIFF
--- a/src/airflow_ldap_auth_manager/ldap_auth_manager.py
+++ b/src/airflow_ldap_auth_manager/ldap_auth_manager.py
@@ -329,8 +329,8 @@ class LdapAuthManager(BaseAuthManager[LdapUser]):
         return f"/auth/login?next={next_url}"
 
     def get_url_logout(self) -> Optional[str]:
-        """Return the configured logout redirect target."""
-        return conf.get("ldap_auth_manager", "logout_redirect", fallback="/")
+        """Return the auth manager logout endpoint."""
+        return "/auth/logout"
 
     @override
     def serialize_user(self, user: LdapUser) -> dict:
@@ -442,6 +442,9 @@ class LdapAuthManager(BaseAuthManager[LdapUser]):
             - If write_scope == "dag_run" (or DagAccessEntity.DAG_RUN), Editor+
             - Else Admin only
         """
+        if not user:
+            return False
+
         role = self._policy.role_for(user.groups)
         if role == Role.NONE:
             return False  # deny outright


### PR DESCRIPTION
It seems get_url_logout should be returning the endpoint of the auth provider to handle the logout, rather than the post-logout redirect. And setting `logout_redirect` to be `/auth/logout` results in an redirect loop being the logout endpoint also redirects to the `logout_redirect` value. So fixing the value to the correct endpoint for this auth manager.

Also - handling `user` coming in null to the `_is_authorized` method, as seeing errors when sessions expire the method tries to access the `groups` property of `user`.