### PR TITLE
Login page style tweak + optional override for the support tip on the login form

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,11 +261,17 @@ logout_redirect = /
 #
 debug_logging = false
 
-# Optional login hint shown under "Sign in". Leave empty to hide.
+# Optional login hint shown under "Sign in" title. Leave empty to hide.
 #
 # Variable: AIRFLOW__LDAP_AUTH_MANAGER__LOGIN_TIP
 #
 login_tip = Using your Company credentials
+
+# Optional override to the support hint shown under the "Sign in" button.
+#
+# Variable: AIRFLOW__LDAP_AUTH_MANAGER__SUPPORT_TIP
+#
+support_tip = Having issues? Raise a ticket to the helpdesk.
 ```
 
 

--- a/src/airflow_ldap_auth_manager/ldap_auth_manager.py
+++ b/src/airflow_ldap_auth_manager/ldap_auth_manager.py
@@ -582,8 +582,9 @@ class LdapAuthManager(BaseAuthManager[LdapUser]):
 
         instance_name = conf.get("api", "instance_name", fallback="Airflow")
         login_tip = conf.get("ldap_auth_manager", "login_tip", fallback="")
+        support_tip = conf.get("ldap_auth_manager", "support_tip", fallback="Having issues? Contact your admin.")
 
-        jinja_env.globals.update(instance_name=instance_name, login_tip=login_tip)
+        jinja_env.globals.update(instance_name=instance_name, login_tip=login_tip, support_tip=support_tip)
 
         def render(name: str, **ctx) -> HTMLResponse:
             """Render ``name`` with the provided context."""

--- a/src/airflow_ldap_auth_manager/static/style.css
+++ b/src/airflow_ldap_auth_manager/static/style.css
@@ -49,11 +49,11 @@ body {
   letter-spacing: 0.2px;
 }
 .logo {
+  margin-left: auto;
   width: 36px;
   height: 36px;
 }
 h2 {
-  margin: 0.25rem 0 1.25rem;
   font-size: 1.4rem;
   font-weight: 700;
 }

--- a/src/airflow_ldap_auth_manager/templates/ldap_login.html
+++ b/src/airflow_ldap_auth_manager/templates/ldap_login.html
@@ -33,7 +33,7 @@
           <button type="submit">Sign in</button>
         </div>
       </form>
-      <div class="foot almost-hidden">Having issues? Contact someone nice.</div>
+      <div class="foot almost-hidden">{{ support_tip }}</div>
     </div>
   </div>
   <script>try{document.getElementById('username').focus()}catch(e){}</script>

--- a/src/airflow_ldap_auth_manager/templates/ldap_login.html
+++ b/src/airflow_ldap_auth_manager/templates/ldap_login.html
@@ -11,10 +11,10 @@
   <div class="wrap">
     <div class="card">
       <div class="brand">
+	<h2>Sign in</h2>
         <img src="/auth/static/airflow.svg" alt="Airflow" class="logo"/>
-        <h1>{{ instance_name | e }}</h1>
+	<h1>{{ instance_name | e }}</h1>
       </div>
-      <h2>Sign in</h2>
       {% if login_tip %}<h4>{{ login_tip | e }}</h4>{% endif %}
 
       {% if error %}<div class="error">{{ error }}</div>{% endif %}
@@ -33,7 +33,7 @@
           <button type="submit">Sign in</button>
         </div>
       </form>
-      <div class="foot almost-hidden">Having issues? Contact your admin.</div>
+      <div class="foot almost-hidden">Having issues? Contact someone nice.</div>
     </div>
   </div>
   <script>try{document.getElementById('username').focus()}catch(e){}</script>


### PR DESCRIPTION
Tweak the login form look, just to bring the Airflow title and icon inline with the Sign In title.

So goes from this...
<img width="1024" height="510" alt="Screenshot from 2026-02-05 01-13-40" src="https://github.com/user-attachments/assets/75f42f70-6fe6-42ff-aa3d-14c5601035c0" />

... to this...
<img width="1024" height="510" alt="Screenshot from 2026-02-05 01-10-04" src="https://github.com/user-attachments/assets/d671a933-a12e-4df4-89fb-24aa711f431c" />

Purely a vanity thing, but just looked a little odd to me the way it was before, so thought I'd propose this, but like no big bother if you prefer it how it is already =)

Also added additional `support_tip` configuration to allow the support prompt at the bottom to be changed as people need.